### PR TITLE
Rename global variables naming style and add debug level

### DIFF
--- a/source/loader/layers/sanitizer/asan_interceptor.cpp
+++ b/source/loader/layers/sanitizer/asan_interceptor.cpp
@@ -30,7 +30,7 @@ const auto kSPIR_ShadowGlobalEnd = "__spirv_AsanShadowGlobalEnd";
 const auto kSPIR_ShadowLocalStart = "__spirv_AsanShadowLocalStart";
 const auto kSPIR_ShadowLocalEnd = "__spirv_AsanShadowLocalEnd";
 
-constexpr auto kSPIR_SanitizerReportMem = "__spirv_AsanSanitizerReportMem";
+const auto kSPIR_SanitizerReportMem = "__spirv_AsanSanitizerReportMem";
 
 const auto kSPIR_DeviceType = "__spirv_AsanDeviceType";
 const auto kSPIR_DebugLevel = "__spirv_AsanDebugLevel";

--- a/source/loader/layers/sanitizer/asan_interceptor.hpp
+++ b/source/loader/layers/sanitizer/asan_interceptor.hpp
@@ -32,7 +32,7 @@ struct USMAllocInfo {
     USMMemoryType Type;
 };
 
-enum class DeviceType { UNKNOWN, CPU, GPU_PVC, GPU_DG2 };
+enum class DeviceType : uint32_t { UNKNOWN, CPU, GPU_PVC, GPU_DG2 };
 
 struct DeviceInfo {
     DeviceType Type;
@@ -158,6 +158,7 @@ class SanitizerInterceptor {
     ur_shared_mutex m_ContextMapMutex;
 
     bool m_IsInASanContext;
+    uint32_t m_DebugLevel;
 };
 
 } // namespace ur_sanitizer_layer


### PR DESCRIPTION
- Rename exported global variables to spirv style
- add spirv_AsanDebugLevel variable to control printing debug message in libdevice, and reuse "UR_LOG_SANITIZER" to control status (like ur logger)
